### PR TITLE
Changed default notebook code indenting.

### DIFF
--- a/practical0.ipynb
+++ b/practical0.ipynb
@@ -61,6 +61,33 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we begin, please set the default notebook code indenting to two spaces using the following javascript."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%%javascript\n",
+    "\n",
+    "var cell = Jupyter.notebook.get_selected_cell();\n",
+    "var config = cell.config;\n",
+    "var patch = {\n",
+    "      CodeCell:{\n",
+    "        cm_config:{indentUnit:2}\n",
+    "      }\n",
+    "    }\n",
+    "config.update(patch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "CV6OV42I5q1R"
@@ -2155,6 +2182,7 @@
      }
     },
     "colab_type": "code",
+    "collapsed": true,
     "id": "nwFkFb_d5q47"
    },
    "outputs": [],
@@ -3967,6 +3995,7 @@
      }
     },
     "colab_type": "code",
+    "collapsed": true,
     "id": "0bTVXB7L5q6g"
    },
    "outputs": [],


### PR DESCRIPTION
In practical1 there seems to be a mismatch between the default code indenting setting on the VM notebooks on AWS and the indenting used in the code (making several of the code snippets appear in red). The code uses two spaces and I think the default is set to four spaces, therefore I added some javascript in practical0 to set the notebook default indenting on the VMs to 2 spaces.