### PR TITLE
Fixed a few typos in practical 4

### DIFF
--- a/practical4.ipynb
+++ b/practical4.ipynb
@@ -993,7 +993,7 @@
         "\n",
         "1. First, the `BasicLSTM` Cell uses no gating to create the proposed new hidden state (original notation uses g, but I use tilde h):\n",
         "\n",
-        "      $\\tilde{h}_t = \\phi(W h_{t-1}) + Ux_t + b)$\n",
+        "      $\\tilde{h}_t = \\phi(W h_{t-1} + Ux_t + b)$\n",
         "\n",
         "2. Then it updates its internal memory to be a combination of the previous memory $c_{t-1}$ (multiplied/modulated by the forget gates $f_t$) and the new proposed state $\\tilde{h}_t$ (modulated by the input gates $i_t$):\n",
         "\n",

--- a/practical4.ipynb
+++ b/practical4.ipynb
@@ -1415,7 +1415,7 @@
         "def build_train_eval_and_plot(model_params, train_params, verbose=True):\n",
         "  \n",
         "  tf.reset_default_graph()\n",
-        "  m = Recurrentlassifier(model_params)\n",
+        "  m = RecurrentClassifier(model_params)\n",
         "\n",
         "  with tf.Session() as sess:\n",
         "    # Train model on the MNIST dataset.\n",


### PR DESCRIPTION
As discussed on the piazza thread:

1. In the "The Long Short-Term Memory unit (LSTM)" section, I think that the line $$\tilde{h}_t = \phi(W h_{t-1}) + Ux_t + b)$$ has an extra ")" after the $$ h_{t-1}$$. 
2. In the build_train_eval_and_plot function, the line m = Recurrentlassifier(model_params), should rather be m = RecurrentClassifier(model_params).



