### PR TITLE
Fixed typos in practical3

### DIFF
--- a/practical3.ipynb
+++ b/practical3.ipynb
@@ -115,7 +115,7 @@
    },
    "source": [
     "## Convolutional Layers\n",
-    "A convolutional layer maps an **input volume** to an **output volume** through a set of **learnable filters**, which make up the parameters of the layer. Every filter is small spatially (along width and height), but extends through the full depth of the input volume. (Eg: A filter in the first layer of a ConvNet might have size 5x5x3). During the forward pass, we colvolve (\"slide\") each filter across the width and height of the input volume and compute dot products between the entries of the filter and the input at any position. As we slide the filter over the width and height of the input volume we will produce a 2-dimensional activation map that gives the responses of that filter at every spatial position. Each convolutional layer will have a set of filters, and each of them will produce a separate 2-dimensional activation map. We will stack these activation maps along the depth dimension to produce the output volume.\n",
+    "A convolutional layer maps an **input volume** to an **output volume** through a set of **learnable filters**, which make up the parameters of the layer. Every filter is small spatially (along width and height), but extends through the full depth of the input volume. (Eg: A filter in the first layer of a ConvNet might have size 5x5x3). During the forward pass, we convolve (\"slide\") each filter across the width and height of the input volume and compute dot products between the entries of the filter and the input at any position. As we slide the filter over the width and height of the input volume we will produce a 2-dimensional activation map that gives the responses of that filter at every spatial position. Each convolutional layer will have a set of filters, and each of them will produce a separate 2-dimensional activation map. We will stack these activation maps along the depth dimension to produce the output volume.\n",
     "\n",
     "### What size is the output volume?\n",
     "The size of the output volume is controlled by the hyperparameters of the convolutional layer:\n",
@@ -503,7 +503,7 @@
     "## (Max) Pooling Layers\n",
     "The purpose of a pooling layer is to is to reduce the spatial size of the representation and therefore control the number of parameters in the network. A pooling layer has no trainable parameters itself. It applies some 2D aggegation operation (usually a MAX, but others like average may also be used) to regions of the input volume. This is done independently for each depth dimension of the input. For example, a 2x2 max pooling operation with a stride of 2, downsamples every depth slice of the input by 2 along both the width and height. \n",
     "\n",
-    "The output volume of a pooling layer alwyas has the same depth as the input volume. The width and height are calcualted as follows:\n",
+    "The output volume of a pooling layer always has the same depth as the input volume. The width and height are calcualted as follows:\n",
     "$(W−F)/S+1$ where W is the width/height of the "
    ]
   },


### PR DESCRIPTION
Fixed a few minor typos in practical3.

* colvolve -> convolve
* alwyas -> always